### PR TITLE
The 'starteKonfetti' function in 'js/effects.js' creates timeouts to …

### DIFF
--- a/js/effects.js
+++ b/js/effects.js
@@ -28,6 +28,10 @@ export function starteKonfetti(container = document.body) {
 
         const timeout = setTimeout(() => {
             konfetti.remove();
+            const index = timeouts.indexOf(timeout);
+            if (index > -1) {
+                timeouts.splice(index, 1);
+            }
         }, KONFETTI_BASE_DURATION_MS + Math.random() * KONFETTI_RANDOM_DURATION_MS);
         timeouts.push(timeout);
     }


### PR DESCRIPTION
### **User description**
…remove konfetti elements but did not remove the timeout IDs from the 'timeouts' array after they executed.

This could lead to a memory leak if the returned 'cleanup' function is held for a long time, as the 'timeouts' array would grow with completed IDs.

This change modifies the setTimeout callback to find and remove its own timeout ID from the 'timeouts' array upon completion, preventing the array from accumulating unnecessary IDs.


___

### **PR Type**
Bug fix


___

### **Description**
- Fix memory leak in konfetti timeout cleanup

- Remove completed timeout IDs from tracking array

- Prevent accumulation of stale timeout references


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["setTimeout creates timeout"] --> B["Timeout executes"]
  B --> C["Remove konfetti element"]
  B --> D["Find timeout ID in array"]
  D --> E["Remove timeout ID from array"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>effects.js</strong><dd><code>Fix timeout ID cleanup in konfetti function</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

js/effects.js

<ul><li>Add cleanup logic to remove timeout IDs from tracking array<br> <li> Find and splice completed timeout ID after konfetti removal<br> <li> Prevent memory leak from accumulating stale timeout references</ul>


</details>


  </td>
  <td><a href="https://github.com/DaFum/weekplan/pull/19/files#diff-8f977b3d65335efcded04b3287802b01567ff317b5ed293308d402dba16b16e4">+4/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

