### PR TITLE
fix: robust Tone.js loading

### DIFF
--- a/.github/workflows/gemini-pr-review.yml
+++ b/.github/workflows/gemini-pr-review.yml
@@ -25,8 +25,7 @@ jobs:
         run: |
           npm install --silent --no-audit --prefer-offline \
             --global @google/gemini-cli@0.1.12
-
-yaml
+            
       - name: Check for required secrets
         id: check_secrets
         run: |

--- a/js/audio.js
+++ b/js/audio.js
@@ -62,11 +62,6 @@ export async function initSounds() {
         }
     }
 
-    if (!Tone || !Tone.Synth) {
-        console.error('Tone.js could not be loaded or audio synthesizers could not be created. Audio functions are disabled.');
-        updateState({ sounds: {} });
-        return;
-    }
 
     // Create the synthesizers
     const sounds = {

--- a/js/audio.js
+++ b/js/audio.js
@@ -16,25 +16,51 @@ import { updateState } from './state.js';
  * The created instances are saved under the `sounds` key by calling `updateState({ sounds })`.
  */
 export async function initSounds() {
+    let Tone;
     try {
-        // Dynamically import the Tone.js library with a timeout
+        // Try to dynamically import the Tone.js module with a timeout
         const importPromise = import('https://cdnjs.cloudflare.com/ajax/libs/tone/14.7.77/Tone.js');
         const timeoutPromise = new Promise((_, reject) =>
             setTimeout(() => reject(new Error("Tone.js import timed out")), 5000)
         );
-
-        const Tone = await Promise.race([importPromise, timeoutPromise]);
-        // Create the synthesizers
-        const sounds = {
-            complete: new Tone.default.Synth({ oscillator: { type: "sine" }, envelope: { attack: 0.005, decay: 0.1, sustain: 0.3, release: 0.5 } }).toDestination(),
-            confetti: new Tone.default.Synth({ oscillator: { type: "triangle" }, envelope: { attack: 0.01, decay: 0.2, sustain: 0.2, release: 0.5 } }).toDestination(),
-            coin: new Tone.default.Synth({ oscillator: { type: "square" }, envelope: { attack: 0.01, decay: 0.1, sustain: 0.1, release: 0.1 } }).toDestination()
-        };
-        // Update the application state with the created sounds
-        updateState({ sounds });
-    } catch (error) {
-        // Log an error if Tone.js could not be loaded or synthesizer creation failed
-        console.error("Tone.js could not be loaded or audio synthesizers could not be created. Audio functions are disabled.", error);
-        updateState({ sounds: {} });
+        const module = await Promise.race([importPromise, timeoutPromise]);
+        Tone = module?.default || module?.Tone || module;
+    } catch {
+        Tone = null;
     }
+
+    if (!Tone || !Tone.Synth) {
+        // Fallback: load UMD build via script tag
+        try {
+            Tone = await new Promise((resolve, reject) => {
+                const script = document.createElement('script');
+                script.src = 'https://cdnjs.cloudflare.com/ajax/libs/tone/14.7.77/Tone.js';
+                script.async = true;
+                script.onload = () => resolve(window.Tone);
+                script.onerror = () => reject(new Error('Tone.js script failed to load'));
+                document.head.appendChild(script);
+                setTimeout(() => reject(new Error('Tone.js script load timed out')), 5000);
+            });
+        } catch (error) {
+            console.error('Tone.js could not be loaded or audio synthesizers could not be created. Audio functions are disabled.', error);
+            updateState({ sounds: {} });
+            return;
+        }
+    }
+
+    if (!Tone || !Tone.Synth) {
+        console.error('Tone.js could not be loaded or audio synthesizers could not be created. Audio functions are disabled.');
+        updateState({ sounds: {} });
+        return;
+    }
+
+    // Create the synthesizers
+    const sounds = {
+        complete: new Tone.Synth({ oscillator: { type: 'sine' }, envelope: { attack: 0.005, decay: 0.1, sustain: 0.3, release: 0.5 } }).toDestination(),
+        confetti: new Tone.Synth({ oscillator: { type: 'triangle' }, envelope: { attack: 0.01, decay: 0.2, sustain: 0.2, release: 0.5 } }).toDestination(),
+        coin: new Tone.Synth({ oscillator: { type: 'square' }, envelope: { attack: 0.01, decay: 0.1, sustain: 0.1, release: 0.1 } }).toDestination()
+    };
+
+    // Update the application state with the created sounds
+    updateState({ sounds });
 }

--- a/js/audio.js
+++ b/js/audio.js
@@ -39,7 +39,20 @@ export async function initSounds() {
                 script.async = true;
                 script.onload = () => resolve(window.Tone);
                 script.onerror = () => reject(new Error('Tone.js script failed to load'));
-                document.head.appendChild(script);
+                const timeoutId = setTimeout(() => {
+                  document.head.removeChild(script);
+                  reject(new Error('Tone.js script load timed out'));
+                }, 5000);
+                script.onload = () => {
+                  clearTimeout(timeoutId);
+                  document.head.removeChild(script);
+                  resolve(window.Tone);
+                };
+                script.onerror = () => {
+                  clearTimeout(timeoutId);
+                  document.head.removeChild(script);
+                  reject(new Error('Tone.js script failed to load'));
+                };
                 setTimeout(() => reject(new Error('Tone.js script load timed out')), 5000);
             });
         } catch (error) {

--- a/js/audio.js
+++ b/js/audio.js
@@ -25,7 +25,8 @@ export async function initSounds() {
         );
         const module = await Promise.race([importPromise, timeoutPromise]);
         Tone = module?.default || module?.Tone || module;
-    } catch {
+    } catch (error) {
+        console.warn("Tone.js dynamic import failed, falling back to script tag.", error);
         Tone = null;
     }
 


### PR DESCRIPTION
### **User description**
## Summary
- load Tone.js via dynamic import with timeout
- fall back to script tag and `window.Tone` when import fails
- use `Tone.Synth` constructors for sound effects

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b4cfd667f08323b90b50b43df47aff


___

### **PR Type**
Bug fix


___

### **Description**
- Implement robust Tone.js loading with fallback mechanism

- Add timeout protection for dynamic imports

- Support both ES module and UMD builds

- Fix synthesizer constructor calls


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Dynamic Import"] --> B{"Import Success?"}
  B -->|Yes| C["Use Module"]
  B -->|No| D["Script Tag Fallback"]
  D --> E{"Script Load Success?"}
  E -->|Yes| F["Use window.Tone"]
  E -->|No| G["Disable Audio"]
  C --> H["Create Synthesizers"]
  F --> H
  G --> I["Empty Sounds State"]
  H --> J["Update State"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>audio.js</strong><dd><code>Robust Tone.js loading with fallback</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

js/audio.js

<ul><li>Add fallback script tag loading when dynamic import fails<br> <li> Implement timeout protection for both import methods<br> <li> Fix Tone.Synth constructor calls (remove <code>.default</code>)<br> <li> Improve error handling and validation</ul>


</details>


  </td>
  <td><a href="https://github.com/DaFum/weekplan/pull/30/files#diff-88177ba64897082ce1d4ab86a3d82e3898101b7c0ab5f4752a31a2cdcebfd3af">+39/-13</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

